### PR TITLE
Update GITHUB_URL constant

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,7 @@ export const marqueeKeywords = [
 ];
 
 // Links
-export const GITHUB_URL = 'https://github.com/astrolicious/studiocms';
+export const GITHUB_URL = 'https://github.com/withstudiocms/studiocms';
 export const SPONSOR_URL = 'https://github.com/withstudiocms';
 export const DISCORD_URL = 'https://chat.studiocms.dev/';
 export const DOCS_URL = 'https://docs.studiocms.dev/';


### PR DESCRIPTION
This pull request includes a minor update to the `GITHUB_URL` constant in the `src/constants.ts` file. The URL has been changed to reflect the new repository location.

* [`src/constants.ts`](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L14-R14): Updated the `GITHUB_URL` to `https://github.com/withstudiocms/studiocms`.