### PR TITLE
Add mergebot workflow

### DIFF
--- a/.github/workflows/mergebot.yml
+++ b/.github/workflows/mergebot.yml
@@ -1,0 +1,12 @@
+name: mergebot
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  mergebot:
+    if: ${{ github.repository_owner == 'withstudiocms' }}
+    uses: withstudiocms/mergebot@main
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_MERGEBOT }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow named `mergebot` to automate the merging process for the main branch. The most important change includes the addition of a new workflow configuration file.

New GitHub Actions workflow:

* [`.github/workflows/mergebot.yml`](diffhunk://#diff-ad64cc54ac2c68e8015ab82176187923f57231c85316454a19611a16db14bb6fR1-R12): Added a new workflow named `mergebot` that triggers on pushes to the main branch and uses the `withstudiocms/mergebot` action. It includes a condition to run only if the repository owner is `withstudiocms` and uses a secret for the Discord webhook.