### PR TITLE
Update first-time-pr.yml

### DIFF
--- a/.github/workflows/first-time-pr.yml
+++ b/.github/workflows/first-time-pr.yml
@@ -4,61 +4,13 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  pull-requests: write
-  actions: write
-  issues: write
-
 jobs:
   welcome:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
-        with:
-          github-token: ${{ secrets.STUDIOCMS_SERVICE_TOKEN }}
-          script: |
-            if (context.payload.pull_request.merged) {
-              const creator = context.payload.pull_request.user.login
-              const owner = context.repo.owner
-              const repo = context.repo.repo
-              const res = await github.rest.search.issuesAndPullRequests({
-                q: `is:pr is:closed author:${creator} repo:${owner}/${repo}`
-              })
-
-              const mergedPRs = res.data.items.filter(pr => pr.number !== context.payload.pull_request.number)
-
-              if (mergedPRs.length === 0) {
-                  await github.rest.issues.createComment({
-                    issue_number: context.issue.number,
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    body: `**Welcome** @${creator}, to the Contributor Squad! 🎉\n\nIf you haven't already, please join our [Discord community](https://chat.studiocms.dev), to stay in the loop for any future help we may need!`
-                  })
-                  
-                  await fetch(`${{ secrets.DISCORD_FTPR }}`, {
-                    method: 'POST',
-                    headers: {
-                      'Accept': 'application/json',
-                      'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({
-                      content: `<@&${{ secrets.DISCORD_ROLE_HONOURED }}>, <@&${{ secrets.DISCORD_ROLE_REVERED }}>, <@&${{ secrets.DISCORD_ROLE_EXALTED }}>`,
-                      tts: false,
-                      embeds: [
-                        {
-                          "id": 661098315,
-                          "description": `New Website Contributor - ${creator} has had their first PR merged! 🎉\nMerged PR: [PR# ${context.issue.number}](https://github.com/withstudiocms/studiocms.dev/pull/${context.issue.number})`,
-                          "fields": [],
-                          "author": {
-                            "name": "StudioCMS Contributor Alert",
-                            "icon_url": "https://github.com/withstudiocms/studiocms.dev/blob/main/assets/logo-discord.png?raw=true"
-                          },
-                          "title": "🚨 FIRST TIME CONTRIBUTOR 🚨"
-                        }
-                      ],
-                      components: [],
-                      actions: {}
-                  })
-                })
-              }
-            }
+    if: ${{ github.repository_owner == 'withstudiocms' }}
+    uses: withstudiocms/automations/.github/workflows/first-time-pr.yml@main
+    secrets:
+      SERVICE_TOKEN: ${{ secrets.STUDIOCMS_SERVICE_TOKEN }}
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_MERGEBOT }}
+      DISCORD_ROLE_HONOURED: ${{ secrets.DISCORD_ROLE_HONOURED }}
+      DISCORD_ROLE_REVERED: ${{ secrets.DISCORD_ROLE_REVERED }}
+      DISCORD_ROLE_EXALTED: ${{ secrets.DISCORD_ROLE_EXALTED }}


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflow configuration for handling first-time pull requests. The main change is the refactoring of the workflow to use a reusable workflow from another repository, which simplifies the configuration and reduces code duplication.

Key changes in the workflow configuration:

* [`.github/workflows/first-time-pr.yml`](diffhunk://#diff-6ee9d23fc26f3b6bdf702ef5ade37179bd3bc0d08454e060883e56d39ee7116cL7-R16): Refactored to use a reusable workflow from `withstudiocms/automations` repository and removed the inline script for handling first-time pull requests.