### PR TITLE
Update turso URL with Sponsored link

### DIFF
--- a/src/share-link.ts
+++ b/src/share-link.ts
@@ -1,15 +1,8 @@
 export const sponsors = {
 	turso: {
-		docs: {
-			sidebarSponsorLink: 'https://turso.tech',
-			installCLILink: 'https://docs.turso.tech/cli/installation',
-			loginsignupLink: 'https://docs.turso.tech/cli/authentication',
-		},
 		web: {
-			sponsorLink: 'https://turso.tech',
+			sponsorLink: 'https://tur.so/studiocms',
 		},
-		// TODO: Add Turso specific links when they are provided to us.
-		// Also, switch to utilizing these new links within the websites.
 	},
 };
 


### PR DESCRIPTION
This pull request includes a small change to the `src/share-link.ts` file. The change updates the sponsor link for Turso in the `web` section and removes outdated and unused links from the `docs` section.

* [`src/share-link.ts`](diffhunk://#diff-8fd115764db5893e351767566fccc60c3b7910ea1afaaf20ac5894ac392e6a0aL3-L12): Updated the `sponsorLink` for Turso in the `web` section and removed outdated links from the `docs` section.