### PR TITLE
Add BlueSky post id to blogpost

### DIFF
--- a/src/content/blog/new-domain-new-discord-same-project.md
+++ b/src/content/blog/new-domain-new-discord-same-project.md
@@ -1,6 +1,8 @@
 ---
 title: New Domain, new Discord, same Project!
 description: .xyz is out, .dev is the new black.
+blueSky:
+  postId: 3lbxo6sexqk2a
 publishDate: 2024-11-27
 ogVariant: winter
 author: louis-escher


### PR DESCRIPTION
This pull request includes a small change to the `src/content/blog/new-domain-new-discord-same-project.md` file. The change adds a `blueSky` section with a `postId` to the blog post metadata.

* [`src/content/blog/new-domain-new-discord-same-project.md`](diffhunk://#diff-ec5cf67a1261bf4819a16e4dc9f49ee3c5b144b72a05be39a314c527cdf781c0R4-R5): Added a `blueSky` section with a `postId` to the blog post metadata.