### PR TITLE
Add bluesky comments connection to v0.3 post for ui lib

### DIFF
--- a/src/content/blog/studiocms-ui-0-3-0.md
+++ b/src/content/blog/studiocms-ui-0-3-0.md
@@ -3,6 +3,8 @@ title: "StudioCMS UI v0.3.0 - The Accessibility Update"
 author: louis-escher
 publishDate: 2024-12-19
 description: We're releasing @studiocms/ui v0.3.0!
+blueSky:
+  postId: 3ldocyrv7bc2s
 hero:
   image: "./assets/ui-0.3.0.png"
   alt: StudioCMS UI 0.3.0 - The Accessibility Update


### PR DESCRIPTION
This pull request includes a small change to the `src/content/blog/studiocms-ui-0-3-0.md` file. The change adds a `blueSky` section with a `postId` to the blog post metadata.

* [`src/content/blog/studiocms-ui-0-3-0.md`](diffhunk://#diff-839cba0c5289d2219412b128f341a1ec3c2a094c09c9f6758a0adc262b408448R6-R7): Added `blueSky` section with `postId` to the blog post metadata.