### PR TITLE
disable twitter sending

### DIFF
--- a/studiocms.config.mjs
+++ b/studiocms.config.mjs
@@ -26,7 +26,6 @@ export default defineStudioCMSConfig({
 	plugins: [
 		socialPoster({
 			bluesky: true,
-			twitter: true,
 		}),
 	],
 });


### PR DESCRIPTION
Twitter API requires you to pay $200 a month in order to have write access for posts specifically... so disabling this feature