### PR TITLE
fix: Adjust wallpaper image sizes and quality for faster loading times

### DIFF
--- a/src/pages/wallpapers.astro
+++ b/src/pages/wallpapers.astro
@@ -40,11 +40,11 @@ const WALLPAPERS = [
 						<Image
 							src={item.dark as any}
 							alt={item.name}
-							width={960}
-							height={540}
+							width={480}
+							height={270}
 							class="resource-preview"
 							loading="eager"
-							quality={100}
+							quality={80}
 						/>
 						<a class="download-button dark" href={item.dark} download aria-label={`Download ${item.name} dark wallpaper`}>
 							<Icon name="arrow-down-tray" width={20} height={20} />
@@ -52,11 +52,11 @@ const WALLPAPERS = [
 						<Image
 							src={item.light as any}
 							alt={item.name}
-							width={960}
-							height={540}
+							width={480}
+							height={270}
 							class="resource-preview light"
 							loading="eager"
-							quality={100}
+							quality={80}
 						/>
 						<a class="download-button light" href={item.light} download aria-label={`Download ${item.name} light wallpaper`}>
 							<Icon name="arrow-down-tray" width={20} height={20} />


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Just a quick fix. Noticed that wallpapers took a fairly long time to get downloaded on first visit so I figured this would be a welcome improvement!

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Wallpaper preview images now use smaller dimensions and slightly reduced quality for both dark and light modes, improving load times and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->