### PR TITLE
Fix head preload tags

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -78,7 +78,7 @@ const path = Astro.originPathname;
   <link rel="preload" as="font" type="font/woff2" crossorigin="anonymous" href={onestWoff2} />
   <link rel="preload" as="image" href="/noise.webp" />
   {path === '/' && (
-    <link rel="preload" as="video" href="https://louisescher.dev/studiocms-trailer.mp4" />
+    <link rel="preload" as="video" href="https://cdn.studiocms.dev/studiocms-trailer.mp4" />
     <link
       rel="preload"
       as="image"

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -76,7 +76,7 @@ const path = Astro.originPathname;
   <link rel="icon" href="https://cdn.studiocms.dev/favicon-dark.png" type="image/png" media="(prefers-color-scheme: light)" />
   <link rel="icon" href="https://cdn.studiocms.dev/favicon.svg" type="image/svg+xml" />
   <link rel="preload" as="font" type="font/woff2" crossorigin="anonymous" href={onestWoff2} />
-  <link rel="preload" as="image" crossorigin="anonymous" href="/noise.webp" />
+  <link rel="preload" as="image" type="image/webp" crossorigin="anonymous" href="/noise.webp" />
   {path === '/' && (
     <link 
       rel="preload"

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -76,15 +76,22 @@ const path = Astro.originPathname;
   <link rel="icon" href="https://cdn.studiocms.dev/favicon-dark.png" type="image/png" media="(prefers-color-scheme: light)" />
   <link rel="icon" href="https://cdn.studiocms.dev/favicon.svg" type="image/svg+xml" />
   <link rel="preload" as="font" type="font/woff2" crossorigin="anonymous" href={onestWoff2} />
-  <link rel="preload" as="image" href="/noise.webp" />
+  <link rel="preload" as="image" crossorigin="anonymous" href="/noise.webp" />
   {path === '/' && (
-    <link rel="preload" as="video" href="https://cdn.studiocms.dev/studiocms-trailer.mp4" />
+    <link 
+      rel="preload"
+      as="video"
+      href="https://cdn.studiocms.dev/studiocms-trailer.mp4"
+      crossorigin="anonymous"
+      type="video/mp4"
+      />
     <link
       rel="preload"
       as="image"
       fetchpriority="high"
       href={videoPosterImage}
-    />
+      crossorigin="anonymous"
+      />
   )}
   <link rel="alternate" type="application/rss+xml" title={title} href={RSSFeed} />
 </head>


### PR DESCRIPTION
This pull request includes a minor update to the `src/components/Head.astro` file. The change updates the URL of a preloaded video to use our CDN to match the current one on the [`pages/index.astro`](https://github.com/withstudiocms/studiocms.dev/blob/50e80cec81b14b87f2969e78070e02e5880404de/src/pages/index.astro#L117)

* [`src/components/Head.astro`](diffhunk://#diff-a1e92208f865df9873b46986ec1a34de409d38bc50779c9d719cd8f580c56044L81-R81): Updated the `href` attribute of the preloaded video link to use `https://cdn.studiocms.dev/studiocms-trailer.mp4` instead of `https://louisescher.dev/studiocms-trailer.mp4`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the video preload link on the homepage to use a new video URL for improved resource delivery.
  * Enhanced resource loading by adding cross-origin attributes to image and video preload links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->