### PR TITLE
fix: Use normal HTML img element for author images

### DIFF
--- a/www/src/pages/blog/[slug].astro
+++ b/www/src/pages/blog/[slug].astro
@@ -34,7 +34,14 @@ const author = await runSDK(SDKCoreJs.GET.users.byId(page.data.authorId!));
 		<hr />
 		<div class="article-info">
 			{author?.avatar && (
-				<Image src={author.avatar} alt={author.name} class="article-card-author-avatar" width={48} height={48} />
+				<img
+					src={author.avatar}
+					alt={author.name}
+					class="article-card-author-avatar"
+					width={48}
+					height={48}
+					onerror="this.src='https://cdn.studiocms.dev/default_avatar.png'"
+				/>
 			)}
 			<div class="info-text">
 				<p>{author?.name}</p>

--- a/www/src/pages/blog/index.astro
+++ b/www/src/pages/blog/index.astro
@@ -1,5 +1,4 @@
 ---
-import { Image } from 'astro:assets';
 import { SDKCoreJs, runSDK } from 'studiocms:sdk';
 import PageHeader from '@/components/PageHeader.astro';
 import Layout from '@/layouts/Layout.astro';
@@ -50,11 +49,13 @@ const articles = (await Promise.all(articlePromises))
 						<div class="article-card-details">
 							<div class="article-card-author">
 								{article.author?.avatar && (
-									<Image
+									<img
 										src={article.author.avatar}
 										alt={article.author.name}
 										class="article-card-author-avatar"
-										inferSize
+										width="32"
+										height="32"
+										onerror="this.src='https://cdn.studiocms.dev/default_avatar.png'"
 									/>
 								)}
 								<p>{article.author?.name}</p>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Fixes an issue where blog pages would fail to load due to libavatar taking too long to respond, causing the image component to fail.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for author avatars on blog pages. When an author's avatar image fails to load, a default placeholder avatar now displays automatically, ensuring a consistent and smooth browsing experience. This fix prevents broken images from appearing and applies to both the main blog listing page and individual blog post detail pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->