### PR TITLE
Make hero-text on landing page bigger and becoming two rows

### DIFF
--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -659,7 +659,8 @@ const [npmDownloads, discordMembers, newestBlogPost, optimizedVideoPoster] = awa
 	}
 
 	.hero h1 {
-		font-size: 2.5em;
+		font-size: 4.8em;
+		text-wrap: balance;
 	}
 
 	.hero p {
@@ -1217,6 +1218,9 @@ const [npmDownloads, discordMembers, newestBlogPost, optimizedVideoPoster] = awa
 	}
 
 	@media screen and (max-width: 640px) {
+    .hero h1 {
+		  font-size: 3em;
+	  }
 		.target-group-div,
 		.target-group-div.enterprise {
 			--reason-cols: 1;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- If aplicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.
Simple update to make the Header hero text be bigger and two lines instead of one. Also a font-size change on smaller screens so it keeps looking good.

<img width="1391" height="660" alt="Skärmavbild 2026-03-09 kl  15 25 46" src="https://github.com/user-attachments/assets/8750ac7d-76e3-4c7a-8bf5-600d243f6064" />


<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined hero headline typography with adjusted sizing and enhanced text wrapping for improved visual balance across desktop layouts.
  * Optimized responsive design to ensure consistent headline appearance and presentation on mobile devices and smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->